### PR TITLE
fix: license field for pep621 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygpod"
 version = "0.0.1"
 description = "Pure Python library for iPod database management - a spiritual successor to libgpod"
 readme = "README.md"
-license = "LGPL-2.1-or-later"
+license = {text = "LGPL-2.1-or-later"}
 requires-python = ">=3.8"
 authors = [
     {name = "Jörg Schuler"},


### PR DESCRIPTION
hey, saw the issue with pip install failing. the license field needs to use the new pep621 format with the text object instead of just a string. this should fix the build error.

let me know if you need anything else!

resolves #1