### PR TITLE
Fix hash58/hash72 detection.

### DIFF
--- a/pygpod/hash/checksum.py
+++ b/pygpod/hash/checksum.py
@@ -10,7 +10,7 @@ from .hash72 import compute_hash72
 logger = logging.getLogger(__name__)
 
 
-def update_checksums(db_data: bytes, firewire_guid: Optional[str] = None) -> bytes:
+def update_checksums(db_data: bytes, firewire_guid: Optional[str] = None, hash_type: Optional[str]=None) -> bytes:
     """Update all checksums in iTunesDB data.
 
     Detects the hashing scheme and applies the appropriate hash.
@@ -23,11 +23,23 @@ def update_checksums(db_data: bytes, firewire_guid: Optional[str] = None) -> byt
     Returns:
         iTunesDB bytes with updated checksums.
     """
+    
     logger.info("Updating checksums")
     if len(db_data) < 0x72 + 46:
         return db_data
-
+    
+    #New hash algorithm - @WoodcraftWorld
+    if hash_type == "HASH58":
+        from .hash58 import compute_hash58
+        logger.debug("Applied hash type: %s", "hash58")
+        return compute_hash58(db_data, firewire_guid)
+    elif hash_type == "HASH72":
+        logger.debug("Applied hash type: %s", "hash72")
+        return compute_hash72(db_data, firewire_guid)
+    """
+    Original hash detection algorithm
     # Check existing hash type by looking at hash72 signature byte
+    
     existing_sig = db_data[0x72 : 0x72 + 46]
 
     if existing_sig[0] == 0x01:
@@ -42,6 +54,6 @@ def update_checksums(db_data: bytes, firewire_guid: Optional[str] = None) -> byt
 
         logger.debug("Applied hash type: %s", "hash58")
         return compute_hash58(db_data, firewire_guid)
-
+        """
     # No hash or hash not computable - return as-is
     return db_data

--- a/pygpod/model/database.py
+++ b/pygpod/model/database.py
@@ -1141,7 +1141,9 @@ class Database:
                     "Or install pyusb for automatic detection:\n"
                     "  pip install pygpod[usb]"
                 )
-            data = update_checksums(data, guid)
+            hash_type=self._device.checksum_type.name
+            #print(hash_type)
+            data = update_checksums(data, guid, hash_type)
 
         db_path = (
             self._device.itunesdb_path()


### PR DESCRIPTION
This allows hash58 iPods to properly be detected and checksummed. Using the existing _device.checksum_type rather than assuming the hash type from the existing hash.